### PR TITLE
Feat: Add custom ids for params

### DIFF
--- a/test_data/products.csv
+++ b/test_data/products.csv
@@ -1,7 +1,7 @@
-product_name
-Sauce Labs Backpack
-Sauce Labs Bike Light
-Sauce Labs Bolt T-Shirt
-Sauce Labs Fleece Jacket
-Sauce Labs Onesie
-Test.allTheThings() T-Shirt (Red)
+product_name,custom_id
+Sauce Labs Backpack,Backpack
+Sauce Labs Bike Light,Bike_Light
+Sauce Labs Bolt T-Shirt,Bolt_T_Shirt
+Sauce Labs Fleece Jacket,Jacket
+Sauce Labs Onesie,Onesie
+Test.allTheThings() T-Shirt (Red),Red_T_Shirt

--- a/test_data/users.csv
+++ b/test_data/users.csv
@@ -1,5 +1,5 @@
-username,password,expected
-standard_user,secret_sauce,inventory_page
-,,empty_fields_error
-locked_out_user,secret_sauce,locked_out_error
-invalid,invalid,invalid_creds_error
+username,password,expected,custom_id
+standard_user,secret_sauce,inventory_page,Standard_User
+,,empty_fields_error,Empty_Fields_User
+locked_out_user,secret_sauce,locked_out_error,Locked_Out_User
+invalid,invalid,invalid_creds_error,Invalid_User

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -3,8 +3,9 @@ from utils.data_loader import load_csv
 import pytest
 
 products = load_csv("./test_data/products.csv")
+custom_ids = [f"{row['custom_id']}" for row in products]
 
-@pytest.mark.parametrize("product", products )
+@pytest.mark.parametrize("product", products, ids=custom_ids)
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_img_click(setup_browser, product):
     driver = setup_browser
@@ -19,7 +20,7 @@ def test_img_click(setup_browser, product):
     assert item_page.url_contains("item.html"), "Clicking product image did not redirect to item page"
 
 
-@pytest.mark.parametrize("product", products)
+@pytest.mark.parametrize("product", products, ids=custom_ids)
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_link_click(setup_browser, product):
     driver = setup_browser

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -3,9 +3,9 @@ from utils.data_loader import load_csv
 import pytest
 
 users = load_csv("./test_data/users.csv")
+custom_ids = [f"{row['custom_id']}" for row in users]
 
-@pytest.mark.parametrize("user", users)
-
+@pytest.mark.parametrize("user", users, ids=custom_ids)
 def test_login(setup_browser, user):
     driver = setup_browser
     driver.get("https://saucedemo.com")


### PR DESCRIPTION
To improve readability of the html-report we added custom-ids for the parameterized tests (currently users and products).