### PR TITLE
fix: #8--screenshots deleted on every report

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser):
         "--intentionally-fail", action="store_true", default=False, help="Run tests that are intentionally failing for demonstration purposes."
     )
 
-def pytest_sessionsionstart(session):
+def pytest_sessionstart(session):
     # Create an empty directory for screenshots
     if os.path.exists(SCREENSHOT_PATH):
         shutil.rmtree(SCREENSHOT_PATH)

--- a/conftest.py
+++ b/conftest.py
@@ -53,7 +53,7 @@ def pytest_runtest_makereport(item, call):
             driver.set_window_size(original_size['width'], original_size['height'])
 
             extras = getattr(report, "extras", [])
-            extras.append(pytest_html.extras.image(SCREENSHOT_PATH_RELATIVE + screenshot_name))
+            extras.append(pytest_html.extras.image(SCREENSHOT_PATH_RELATIVE + "/" + screenshot_name))
             report.extras = extras
 
     return report

--- a/conftest.py
+++ b/conftest.py
@@ -7,10 +7,21 @@ import pytest_html
 import os
 import shutil
 
+
+
+SCREENSHOT_PATH_RELATIVE = "screenshots"
+SCREENSHOT_PATH = "test_reports/" + SCREENSHOT_PATH_RELATIVE
+
 def pytest_addoption(parser):
     parser.addoption(
         "--intentionally-fail", action="store_true", default=False, help="Run tests that are intentionally failing for demonstration purposes."
     )
+
+def pytest_sessionsionstart(session):
+    # Create an empty directory for screenshots
+    if os.path.exists(SCREENSHOT_PATH):
+        shutil.rmtree(SCREENSHOT_PATH)
+    os.mkdir(SCREENSHOT_PATH)
 
 @pytest.fixture(scope="function")
 def setup_browser():
@@ -31,23 +42,18 @@ def pytest_runtest_makereport(item, call):
         driver = item.funcargs.get('setup_browser')
         if driver:
             timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-            screenshot_path = f"test_reports/screenshots"
             screenshot_name = f"{item.name}_{timestamp}.png"
-
-            if os.path.exists(screenshot_path):
-                shutil.rmtree(screenshot_path)
-            os.mkdir(screenshot_path)
  
             original_size = driver.get_window_size()
             required_width = driver.execute_script('return document.body.parentNode.scrollWidth')
             required_height = driver.execute_script('return document.body.parentNode.scrollHeight')
             driver.set_window_size(required_width, required_height)
-            driver.find_element(By.TAG_NAME, 'body').screenshot(screenshot_path
-                                                               + "/" + screenshot_name)
+            driver.find_element(By.TAG_NAME, 'body').screenshot(
+                SCREENSHOT_PATH + "/" + screenshot_name)
             driver.set_window_size(original_size['width'], original_size['height'])
 
             extras = getattr(report, "extras", [])
-            extras.append(pytest_html.extras.image("screenshots/" + screenshot_name))
+            extras.append(pytest_html.extras.image(SCREENSHOT_PATH_RELATIVE + screenshot_name))
             report.extras = extras
 
     return report


### PR DESCRIPTION
The screenshots of failed tests were deleted on every report instead of every pytest run. So, if mutiple tests fail, only the screenshot of the last test was kept. Now the screenshots are deleted on every pytest run, and kept until the next run is started.

