### PR TITLE
Fix #10 Remove useless if-else-statements

### DIFF
--- a/pages/inventory_page.py
+++ b/pages/inventory_page.py
@@ -34,41 +34,29 @@ class InventoryPage(BasePage):
     
     def click_add_to_cart(self, product_name):
         product = self.get_product_by_name(product_name)
-        if product:
-            add_button = product.find_element(*self.add_to_cart_button_locator)
-            add_button.click()
-        else:
-            raise AssertionError(f"Product '{product_name}' not found in inventory")
+        add_button = product.find_element(*self.add_to_cart_button_locator)
+        add_button.click()
         
     def click_remove_from_cart(self, product_name):
         product = self.get_product_by_name(product_name)
-        if product:
-            self.wait_for_element_visible(self.remove_from_cart_button_locator)
-            remove_button = product.find_element(*self.remove_from_cart_button_locator)
-            remove_button.click()
-        else:
-            raise AssertionError(f"Product '{product_name}' not found in inventory")
-    
+        self.wait_for_element_visible(self.remove_from_cart_button_locator)
+        remove_button = product.find_element(*self.remove_from_cart_button_locator)
+        remove_button.click()
+        
     def click_product_link(self, product_name):
         product = self.get_product_by_name(product_name)
-        if product:
-            self.wait_for_element_visible(self.item_link_locator)
-            product_link = product.find_element(*self.item_link_locator)
-            product_link.click()
-            return ItemPage(self.driver)
-        else:
-            raise AssertionError(f"Product '{product_name}' not found in inventory.")
+        self.wait_for_element_visible(self.item_link_locator)
+        product_link = product.find_element(*self.item_link_locator)
+        product_link.click()
+        return ItemPage(self.driver)
                 
     def click_product_img(self, product_name):
         product = self.get_product_by_name(product_name)
-        if product:
-            self.wait_for_element_visible(self.item_img_locator)
-            product_img = product.find_element(*self.item_img_locator)
-            product_img.click()
-            return ItemPage(self.driver)
-        else:
-            raise AssertionError(f"Product '{product_name}' not found in inventory.")
-
+        self.wait_for_element_visible(self.item_img_locator)
+        product_img = product.find_element(*self.item_img_locator)
+        product_img.click()
+        return ItemPage(self.driver)
+    
     def get_num_of_items_in_cart(self):
         cart_item = self.driver.find_element(self.cart_item_count_locator)
         if cart_item:


### PR DESCRIPTION
In 'click_add_to_cart', 'click_remove_from_cart', 'click_product_link', and 'click_product_img', we are getting the product by name and then performing an action. The 'get_product_by_name' method already raises an AssertionError if the product is not found, so the subsequent 'if product' check is redundant. We did remove it together with the else branch.

