### PR TITLE
Fix #11  Refactor LoginPage

### DIFF
--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -35,8 +35,8 @@ class LoginPage(BasePage):
         try:
             self.wait_for_element_visible(error_locator)
             return self 
-        except TimeoutException:
-            AssertionError("Error message not found")
+        except AssertionError:
+            raise AssertionError(f"Error message not found within {self.timeout} seconds. Used locator: {error_locator}")
 
     def login_expect_success(self, username, password):
         self._login(username, password)


### PR DESCRIPTION
The Method 'LoginPage::login_expect_success' used try-except to catch TimeoutException and then raised an AssertionError. But the 'BasePage::wait_for_url" method already raised an AssertionError. We got rid of the try-except-block.

Similarly the 'LoginPage::_login_expect_error' used an try-except to catch TimeoutException and then raised an AssertionError`. But the 'BasePage::wait_for_element_visible" method already raises an AssertionError. We now propagate the AssertionError to give a more specific one.