### PR TITLE
Implement #13  Add standard_login fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ import datetime
 import pytest_html
 import os
 import shutil
-
+from pages.login_page import LoginPage
 
 
 SCREENSHOTS_PATH_RELATIVE = "screenshots"
@@ -23,6 +23,7 @@ def pytest_sessionstart(session):
         shutil.rmtree(SCREENSHOTS_PATH)
     os.makedirs(SCREENSHOTS_PATH)
 
+##### FIXTURES #####
 @pytest.fixture(scope="function")
 def setup_browser():
     # Add headless mode for CI compatibility
@@ -32,6 +33,15 @@ def setup_browser():
     yield driver
     driver.quit()
 
+@pytest.fixture(scope="function")
+def standard_login(setup_browser):
+    driver = setup_browser
+    driver.get("https://saucedemo.com")
+    login_page = LoginPage(driver)
+    return login_page.login_expect_success("standard_user", "secret_sauce")
+    
+
+##### HOOKS #####
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_makereport(item, call):
     # This hook is used to capture the test report and take a screenshot if the test fails

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -7,29 +7,18 @@ custom_ids = [f"{row['custom_id']}" for row in products]
 
 @pytest.mark.parametrize("product", products, ids=custom_ids)
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
-def test_img_click(setup_browser, product):
-    driver = setup_browser
-    driver.get("https://saucedemo.com")
-
+def test_img_click(standard_login, product):
     product_name = product["product_name"]
-    
-    login_page = LoginPage(driver)
-    inventory_page = login_page.login_expect_success("standard_user", "secret_sauce")
+    inventory_page = standard_login
     item_page = inventory_page.click_product_img(product_name)
-
     assert item_page.url_contains("item.html"), "Clicking product image did not redirect to item page"
 
 
 @pytest.mark.parametrize("product", products, ids=custom_ids)
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
-def test_link_click(setup_browser, product):
-    driver = setup_browser
-    driver.get("https://saucedemo.com")
-
+def test_link_click(standard_login, product):
     product_name = product["product_name"]
-        
-    login_page = LoginPage(driver)
-    inventory_page = login_page.login_expect_success("standard_user", "secret_sauce")
+    inventory_page = standard_login
     item_page = inventory_page.click_product_link(product_name)
 
     assert item_page.url_contains("item.html"), "Clicking product link did not redirect to item page"


### PR DESCRIPTION
Logging in as the standard users is needed for a lot of tests, so we added it as a fixture to reduce duplication.