### PR TITLE
Implement #12 Add missing PW test

### DIFF
--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -49,6 +49,8 @@ class LoginPage(BasePage):
     def login_expect_missing_username(self, username, password):
         return self._login_expect_error(username, password, self.alert_missing_user_locator)
     
+    def login_expect_missing_password(self, username, password):
+        return self._login_expect_error(username, password, self.alert_missing_password_locator)
     
     def login_expect_locked_user(self, username, password):
         return self._login_expect_error(username, password, self.alert_locked_user_locator)

--- a/test_data/users.csv
+++ b/test_data/users.csv
@@ -1,5 +1,7 @@
 username,password,expected,custom_id
 standard_user,secret_sauce,inventory_page,Standard_User
 ,,empty_fields_error,Empty_Fields_User
+,secret_sauce,missing_username_error,Missing_Username_User
+standard_user,,missing_password_error,Missing_Password_User
 locked_out_user,secret_sauce,locked_out_error,Locked_Out_User
 invalid,invalid,invalid_creds_error,Invalid_User

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -25,6 +25,14 @@ def test_login(setup_browser, user):
             login_page.login_expect_missing_username(username, password)
             assert login_page.wait_for_element(login_page.alert_missing_user_locator), "Missing username error not displayed"
         
+        case "missing_username_error":
+            login_page.login_expect_missing_username(username, password)
+            assert login_page.wait_for_element(login_page.alert_missing_user_locator), "Missing username error not displayed"
+
+        case "missing_password_error":
+            login_page.login_expect_missing_password(username, password)
+            assert login_page.wait_for_element(login_page.alert_missing_password_locator), "Missing password error not displayed"    
+
         case "locked_out_error":
             login_page.login_expect_locked_user(username, password)
             assert login_page.wait_for_element(login_page.alert_locked_user_locator), "Locked out user error not displayed"
@@ -32,5 +40,6 @@ def test_login(setup_browser, user):
         case "invalid_creds_error":
             login_page.login_expect_invalid_credentials(username, password)
             assert login_page.wait_for_element(login_page.alert_invalid_credentials_locator), "Invalid credentials error not displayed"
+
         case _:
             pytest.fail(f"Unexpected expected value: {expected}")


### PR DESCRIPTION
We already had a test that checked if the error msg is displayed when both username-field and pw-field is empty. Since the error msg is different if only one of them is empty, we now check these cases, too.