### PR TITLE
Fix #18 by disabling PW-leak-prompt

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,6 +28,10 @@ def pytest_sessionstart(session):
 def setup_browser():
     # Add headless mode for CI compatibility
     options = webdriver.ChromeOptions()
+    prefs = {
+        "profile.password_manager_leak_detection_enabled": False
+    }
+    options.add_experimental_option("prefs", prefs)
     options.add_argument("--headless=new")
     driver = webdriver.Chrome(options=options)    
     yield driver


### PR DESCRIPTION
The WebDriver instance for Chrome showed an Password-Breach-Prompt a few miliseconds after logging in. The prompt made it impossible to click on elements of the webpage, which caused tests to fail. We disabled the prompt. 

We did 10 runs of all tests.
Result: All passed, no reruns. 
Conclusion: This might have been the only reason for flaky tests. It might no longer be necessary to mark the inventory_tests as flaky. But we keep it for now and decide later.