### PR TITLE
Fix #26  handle remote flakyness

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,7 +3,6 @@ name: Python Tests
 on:
     pull_request:
         branches: [ main ]  # Runs on PRs targeting "main" branch
-    push:
         
 jobs:
   test:
@@ -36,7 +35,7 @@ jobs:
 
     - name: Run tests with pytest
       run: |
-        pytest --count=50
+        pytest
     
     - name: Compress Screenshots
       uses: clydedz/compress-images@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,6 +3,7 @@ name: Python Tests
 on:
     pull_request:
         branches: [ main ]  # Runs on PRs targeting "main" branch
+    push:
         
 jobs:
   test:
@@ -35,7 +36,7 @@ jobs:
 
     - name: Run tests with pytest
       run: |
-        pytest
+        pytest tests/test_inventory.py
     
     - name: Compress Screenshots
       uses: clydedz/compress-images@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Run tests with pytest
       run: |
-        pytest tests/test_inventory.py
+        pytest --count=20
     
     - name: Compress Screenshots
       uses: clydedz/compress-images@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Run tests with pytest
       run: |
-        pytest --count=20
+        pytest --count=50
     
     - name: Compress Screenshots
       uses: clydedz/compress-images@v1

--- a/conftest.py
+++ b/conftest.py
@@ -47,12 +47,10 @@ def setup_browser():
     options = webdriver.ChromeOptions()
     prefs = {
         "profile": {
-            "enable_password_manager": False,
             "password_manager_leak_detection_enabled": False
-        },
-        "credentials_enable_service": False
-    }
+        }}
     options.add_experimental_option("prefs", prefs)
+    options.add_argument("--disable-features=PasswordLeakToggleMove")
     options.add_argument("--headless=new")
     driver = webdriver.Chrome(options=options)
     yield driver

--- a/conftest.py
+++ b/conftest.py
@@ -46,9 +46,7 @@ def setup_browser():
     """Set up the browser for testing."""
     options = webdriver.ChromeOptions()
     prefs = {
-        "profile": {
-            "password_manager_leak_detection_enabled": False
-        }}
+        "profile.password_manager_leak_detection": False}
     options.add_experimental_option("prefs", prefs)
     options.add_argument("--disable-features=PasswordLeakToggleMove")
     options.add_argument("--headless=new")

--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,11 @@ def setup_browser():
     """Set up the browser for testing."""
     options = webdriver.ChromeOptions()
     prefs = {
-        "profile.password_manager_leak_detection_enabled": False
+        "profile": {
+            "enable_password_manager": False,
+            "password_manager_leak_detection_enabled": False
+        },
+        "credentials_enable_service": False
     }
     options.add_experimental_option("prefs", prefs)
     options.add_argument("--headless=new")
@@ -65,7 +69,6 @@ def standard_login(setup_browser):
     driver.get("https://saucedemo.com")
     login_page = LoginPage(driver)
     return login_page.login_expect_success("standard_user", "secret_sauce")
-
 
 #########
 # HOOKS #

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -39,6 +39,13 @@ class BasePage:
                 f"Page load failed. Expected URL to contain: '{substring}', "
                 f"Current URL: '{current_url}'"
             )
+        
+    def wait_for_page_ready(self):
+        """Waits for the page to be fully loaded."""
+        WebDriverWait(self.driver, self.timeout).until(
+            lambda d: d.execute_script(
+                "return document.readyState") == "complete"
+        )
 
     def wait_for_element(self, locator):
         """Waits for an element to be present in the DOM."""
@@ -91,3 +98,4 @@ class BasePage:
     def input_text(self, locator, text):
         """Inputs text into an element after waiting for it to be visible."""
         self.wait_for_element_visible(locator).send_keys(text)
+

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -39,7 +39,7 @@ class BasePage:
                 f"Page load failed. Expected URL to contain: '{substring}', "
                 f"Current URL: '{current_url}'"
             )
-        
+
     def wait_for_page_ready(self):
         """Waits for the page to be fully loaded."""
         WebDriverWait(self.driver, self.timeout).until(
@@ -98,4 +98,3 @@ class BasePage:
     def input_text(self, locator, text):
         """Inputs text into an element after waiting for it to be visible."""
         self.wait_for_element_visible(locator).send_keys(text)
-

--- a/pages/inventory_page.py
+++ b/pages/inventory_page.py
@@ -63,13 +63,14 @@ class InventoryPage(BasePage):
     def click_add_to_cart(self, product_name):
         """Clicks the 'Add to Cart' button for a product."""
         product = self.get_product_by_name(product_name)
+        self.wait_for_element_clickable(self.add_to_cart_button_locator)
         add_button = product.find_element(*self.add_to_cart_button_locator)
         add_button.click()
 
     def click_remove_from_cart(self, product_name):
         """Clicks the 'Remove from Cart' button for a product."""
         product = self.get_product_by_name(product_name)
-        self.wait_for_element_visible(self.remove_from_cart_button_locator)
+        self.wait_for_element_clickable(self.remove_from_cart_button_locator)
         remove_button = product.find_element(
             *self.remove_from_cart_button_locator
             )
@@ -78,7 +79,7 @@ class InventoryPage(BasePage):
     def click_product_link(self, product_name):
         """Clicks the product link to navigate to the item page."""
         product = self.get_product_by_name(product_name)
-        self.wait_for_element_visible(self.item_link_locator)
+        self.wait_for_element_clickable(self.item_link_locator)
         product_link = product.find_element(*self.item_link_locator)
         product_link.click()
         return ItemPage(self.driver)
@@ -86,7 +87,7 @@ class InventoryPage(BasePage):
     def click_product_img(self, product_name):
         """Clicks the product image to navigate to the item page."""
         product = self.get_product_by_name(product_name)
-        self.wait_for_element_visible(self.item_img_locator)
+        self.wait_for_element_clickable(self.item_img_locator)
         product_img = product.find_element(*self.item_img_locator)
         product_img.click()
         return ItemPage(self.driver)

--- a/pages/inventory_page.py
+++ b/pages/inventory_page.py
@@ -18,6 +18,7 @@ class InventoryPage(BasePage):
     def __init__(self, driver):
         super().__init__(driver)
         self.wait_for_url_contains("inventory.html")
+        self.wait_for_page_ready()
 
         # Locators for the inventory page elements
         self.inventory_item_locator = (

--- a/pages/inventory_page.py
+++ b/pages/inventory_page.py
@@ -45,6 +45,7 @@ class InventoryPage(BasePage):
 
     def get_products(self):
         """Returns a list of all products in the inventory."""
+        self.wait_for_element_visible(self.inventory_item_locator)
         products = self.driver.find_elements(*self.inventory_item_locator)
         return products
 

--- a/pages/item_page.py
+++ b/pages/item_page.py
@@ -16,3 +16,4 @@ class ItemPage(BasePage):
     def __init__(self, driver):
         super().__init__(driver)
         self.wait_for_url_contains("inventory-item.html")
+        self.wait_for_page_ready()

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -19,6 +19,7 @@ class LoginPage(BasePage):
     def __init__(self, driver):
         super().__init__(driver)
         self.wait_for_url_contains("saucedemo.com")
+        self.wait_for_page_ready()
 
         # Locators for the login page elements
         self.username_locator = (

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -19,9 +19,12 @@ def test_img_click(standard_login, product):
     """Test clicking product images on the inventory page."""
     product_name = product["product_name"]
     inventory_page = standard_login
-    item_page = inventory_page.click_product_img(product_name)
-    assert item_page.url_contains("item.html"), ""\
-        "Clicking product image did not redirect to item page"
+    try:
+        item_page = inventory_page.click_product_img(product_name)
+    except AssertionError:
+        raise AssertionError(
+            "Clicking product image did not redirect "
+            f"to item page. Current URL: {item_page.driver.current_url}")
 
 
 @pytest.mark.parametrize("product", products, ids=custom_ids)
@@ -30,9 +33,12 @@ def test_link_click(standard_login, product):
     """Test clicking product links on the inventory page."""
     product_name = product["product_name"]
     inventory_page = standard_login
-    item_page = inventory_page.click_product_link(product_name)
-    assert item_page.url_contains("item.html"), ""\
-        "Clicking product link did not redirect to item page"
+    try:
+        item_page = inventory_page.click_product_link(product_name)
+    except AssertionError:
+        raise AssertionError(
+            "Clicking product link did not redirect "
+            f"to item page. Current URL: {item_page.driver.current_url}")
 
 
 def test_cart_count(standard_login):

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -14,7 +14,7 @@ custom_ids = [f"{row['custom_id']}" for row in products]
 
 
 @pytest.mark.parametrize("product", products, ids=custom_ids)
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_img_click(standard_login, product):
     """Test clicking product images on the inventory page."""
     product_name = product["product_name"]
@@ -28,7 +28,7 @@ def test_img_click(standard_login, product):
 
 
 @pytest.mark.parametrize("product", products, ids=custom_ids)
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_link_click(standard_login, product):
     """Test clicking product links on the inventory page."""
     product_name = product["product_name"]


### PR DESCRIPTION
Tests were failing occasionally (mostly on remote). We tried the following to handle the flaky tests:

- Improve explicit waiting for elements and load pages
- Wait for buttons to be clickable, instead of just visible
- Improve Test Assertions
- Disable Chromes Password Leak Detection (#23 did not work)

It seems like disablingh PW-Leak-Detection did the trick. We validated with 50 runs of each test both locally and on remote. We did not observe any reruns or test failures. 