### PR TITLE
Fix #29 click correct product name

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -95,6 +95,14 @@ class BasePage:
         """Clicks an element after waiting for it to be clickable."""
         self.wait_for_element_clickable(locator).click()
 
+    def click_child_element(self, parent_element, child_locator):
+        """
+        Clicks a child element within a parent element.
+        """
+        child_element = parent_element.find_element(*child_locator)
+        self.wait_for_element_clickable(child_locator)
+        child_element.click()
+
     def input_text(self, locator, text):
         """Inputs text into an element after waiting for it to be visible."""
         self.wait_for_element_visible(locator).send_keys(text)

--- a/pages/inventory_page.py
+++ b/pages/inventory_page.py
@@ -27,9 +27,6 @@ class InventoryPage(BasePage):
         self.item_name_locator = (
             By.CSS_SELECTOR,
             "div[data-test='inventory-item-name']")
-        self.item_link_locator = (
-            By.CSS_SELECTOR,
-            "a[data-test$='title-link']")
         self.item_img_locator = (
             By.CSS_SELECTOR,
             "img[data-test^='inventory-item']"
@@ -80,9 +77,7 @@ class InventoryPage(BasePage):
     def click_product_link(self, product_name):
         """Clicks the product link to navigate to the item page."""
         product = self.get_product_by_name(product_name)
-        self.wait_for_element_clickable(self.item_link_locator)
-        product_link = product.find_element(*self.item_link_locator)
-        product_link.click()
+        self.click_child_element(product, self.item_name_locator)
         return ItemPage(self.driver)
 
     def click_product_img(self, product_name):


### PR DESCRIPTION
In the `test_link_click` method, we tried to click on the wrong web element, which worked on Chrome, but failed on Firefox. Fixed by selecting the correct element.